### PR TITLE
make the topic field optional in the streaming KafkaOutput

### DIFF
--- a/core/src/main/scala/com/amadeus/dataio/pipes/kafka/streaming/KafkaOutput.scala
+++ b/core/src/main/scala/com/amadeus/dataio/pipes/kafka/streaming/KafkaOutput.scala
@@ -67,9 +67,11 @@ case class KafkaOutput(
    */
   private[streaming] def createQueryName(): String = {
 
-    outputName match {
-      case Some(name) => s"QN_${name}_${topic}_${java.util.UUID.randomUUID}"
-      case _          => s"QN_${topic}_${java.util.UUID.randomUUID}"
+    (outputName, topic) match {
+      case (Some(name), Some(t)) => s"QN_${name}_${t}_${java.util.UUID.randomUUID}"
+      case (Some(name), None)    => s"QN_${name}_${java.util.UUID.randomUUID}"
+      case (None, Some(t))       => s"QN_KafkaOutput_${t}_${java.util.UUID.randomUUID}"
+      case _                     => s"QN_KafkaOutput_${java.util.UUID.randomUUID}"
     }
 
   }


### PR DESCRIPTION
The spark-sql-kafka library allows for a single DataFrameWriter to write to different Kafka topics on the cluster, which isn't possible in the current version of Data I/O.

Making the Topic field optional returns this functionality. 

More information on the Kafka Integration Guide for Spark Structured Streaming: https://spark.apache.org/docs/3.2.1/structured-streaming-kafka-integration.html 