### PR TITLE
fix exception thrown at Processor instantiation time

### DIFF
--- a/core/src/main/scala/com/amadeus/dataio/pipeline/Pipeline.scala
+++ b/core/src/main/scala/com/amadeus/dataio/pipeline/Pipeline.scala
@@ -38,14 +38,19 @@ case class Pipeline(config: PipelineConfig) extends Logging {
     val handlerAccessor = HandlerAccessor(config)
 
     logger.info(s"Creating data processor.")
-    val processor = Try {
-      Processor(config.processing.nodes.head) // TODO: refactor the processing config node, having a collection is not necessary anymore
-    }.getOrElse(
+
+    if(config.processing.nodes.size() == 0) {
       throw new Exception(
         "Can not run a data pipeline if there are no configured data processors. " +
           "If no transformation of data is required in your job, you may use com.amadeus.dataio.processing.Identity (explicitly)."
       )
-    )
+    }
+
+    if(config.processing.nodes.size() > 1) {
+      logger.warn("Only one data processor is currently supported by Data I/O. All ")
+    }
+
+    val processor = Processor(config.processing.nodes.head)
 
     logger.info("Running data processor.")
     processor.run(handlerAccessor)


### PR DESCRIPTION
Currently, all instantiation errors are reported as a missing data processor, which is misleading.